### PR TITLE
Fix write image file and dummy bag offsets 

### DIFF
--- a/src/ros/thread/DummyBagThread.cpp
+++ b/src/ros/thread/DummyBagThread.cpp
@@ -48,7 +48,7 @@ DummyBagThread::run()
                 Utils::ROS::writeMessageToBag(std_msgs::msg::Int32(), i, writer, name, timeStamp);
             } else if (type == "Image") {
                 // Lerp from blue to red
-                const auto blue = 255 - (i * (255.0f / (float) m_parameters.messageCount));
+                const auto blue = 255 - ((i - 1) * (255.0f / (float) m_parameters.messageCount));
                 const auto red = 0 + (i * (255.0f / (float) m_parameters.messageCount));
                 cv::Mat mat(720, 1280, CV_8UC3, cv::Scalar(blue, 0, red));
                 sensor_msgs::msg::Image message;

--- a/src/ros/thread/WriteToImageThread.cpp
+++ b/src/ros/thread/WriteToImageThread.cpp
@@ -109,7 +109,7 @@ WriteToImageThread::run()
             // Have to create this as extra string to keep it atomic inside the mutex
             std::stringstream formatedIterationCount;
             // Use leading zeroes
-            formatedIterationCount << std::setw(messageCountNumberOfDigits) << std::setfill('0') << iterationCount << "\n";
+            formatedIterationCount << std::setw(messageCountNumberOfDigits) << std::setfill('0') << iterationCount;
             const auto targetString = targetDirectoryStd + "/" + formatedIterationCount.str() + "." + m_parameters.format.toStdString();
 
             mutex.unlock();


### PR DESCRIPTION
Fixes:
- Dummy Bag Color Generation had a small offset
- There was an unnecessary line break in files generated by the bag-to-images tool.