### PR TITLE
Fixes for pcd to bag tool and ROS dependent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,10 @@ find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-if($ENV{ROS_DISTRO} STREQUAL "jazzy")
-    add_definitions(-DROS_JAZZY)
-else()
+if($ENV{ROS_DISTRO} STREQUAL "humble")
     add_definitions(-DROS_HUMBLE)
+else()
+    add_definitions(-DROS_JAZZY)
 endif()
 
 if(${Qt6_FOUND})

--- a/src/cli/PCDsToBag.cpp
+++ b/src/cli/PCDsToBag.cpp
@@ -83,7 +83,7 @@ main(int argc, char* argv[])
     }
 
     // Create thread and connect to its informations
-    auto* const pcdsToBagThread = new PCDsToBagThread(parameters, std::thread::hardware_concurrency());
+    auto* const pcdsToBagThread = new PCDsToBagThread(parameters);
 
     QObject::connect(pcdsToBagThread, &PCDsToBagThread::progressChanged, [] (const QString& progressString, int progress) {
         const auto progressStringCMD = Utils::CLI::drawProgressString(progress);

--- a/src/ros/thread/BagToImagesThread.cpp
+++ b/src/ros/thread/BagToImagesThread.cpp
@@ -11,10 +11,10 @@
 #include <cmath>
 #include <filesystem>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 BagToImagesThread::BagToImagesThread(const Parameters::BagToImagesParameters& parameters,

--- a/src/ros/thread/BagToVideoThread.cpp
+++ b/src/ros/thread/BagToVideoThread.cpp
@@ -7,10 +7,10 @@
 
 #include "sensor_msgs/msg/image.hpp"
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 BagToVideoThread::BagToVideoThread(const Parameters::BagToVideoParameters& parameters, bool useHardwareAcceleration,

--- a/src/ros/thread/ChangeCompressionBagThread.cpp
+++ b/src/ros/thread/ChangeCompressionBagThread.cpp
@@ -29,10 +29,10 @@ ChangeCompressionBagThread::run()
     outputStorage.uri = targetDirectoryStd;
 
     rosbag2_transport::RecordOptions outputRecord;
-#ifdef ROS_JAZZY
-    outputRecord.all_topics = true;
-#else
+#ifdef ROS_HUMBLE
     outputRecord.all = true;
+#else
+    outputRecord.all_topics = true;
 #endif
     if (m_compress) {
         outputRecord.compression_format = "zstd";

--- a/src/ros/thread/DummyBagThread.cpp
+++ b/src/ros/thread/DummyBagThread.cpp
@@ -12,10 +12,10 @@
 #include <filesystem>
 #include <random>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 DummyBagThread::DummyBagThread(const Parameters::DummyBagParameters& parameters,

--- a/src/ros/thread/EditBagThread.cpp
+++ b/src/ros/thread/EditBagThread.cpp
@@ -108,10 +108,10 @@ EditBagThread::run()
                     message->topic_name = topic.renamedTopicName.toStdString();
                 }
                 if (m_parameters.updateTimestamps) {
-#ifdef ROS_JAZZY
-                    message->recv_timestamp = node->now().nanoseconds();
-#else
+#ifdef ROS_HUMBLE
                     message->time_stamp = node->now().nanoseconds();
+#else
+                    message->recv_timestamp = node->now().nanoseconds();
 #endif
                 }
                 writer.write(message);

--- a/src/ros/thread/PCDsToBagThread.hpp
+++ b/src/ros/thread/PCDsToBagThread.hpp
@@ -10,7 +10,6 @@ class PCDsToBagThread : public BasicThread {
 public:
     explicit
     PCDsToBagThread(const Parameters::PCDsToBagParameters& parameters,
-                    unsigned int                           numberOfThreads,
                     QObject*                               parent = nullptr);
 
     void
@@ -18,6 +17,4 @@ public:
 
 private:
     const Parameters::PCDsToBagParameters& m_parameters;
-
-    const unsigned int m_numberOfThreads;
 };

--- a/src/ros/thread/PublishImagesThread.cpp
+++ b/src/ros/thread/PublishImagesThread.cpp
@@ -2,10 +2,10 @@
 
 #include <opencv2/imgcodecs.hpp>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 #include <filesystem>

--- a/src/ros/thread/PublishVideoThread.cpp
+++ b/src/ros/thread/PublishVideoThread.cpp
@@ -2,10 +2,10 @@
 
 #include <opencv2/videoio.hpp>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 PublishVideoThread::PublishVideoThread(const Parameters::PublishParameters& parameters, bool useHardwareAcceleration,

--- a/src/ros/thread/RecordBagThread.cpp
+++ b/src/ros/thread/RecordBagThread.cpp
@@ -24,10 +24,10 @@ RecordBagThread::run()
 
     rosbag2_transport::RecordOptions recordOptions;
     if (m_parameters.allTopics) {
-#ifdef ROS_JAZZY
-        recordOptions.all_topics = true;
-#else
+#ifdef ROS_HUMBLE
         recordOptions.all = true;
+#else
+        recordOptions.all_topics = true;
 #endif
     } else {
         for (const auto& topic : m_parameters.topics) {

--- a/src/ros/thread/VideoToBagThread.cpp
+++ b/src/ros/thread/VideoToBagThread.cpp
@@ -8,10 +8,10 @@
 
 #include <filesystem>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 VideoToBagThread::VideoToBagThread(const Parameters::VideoToBagParameters& parameters, bool useHardwareAcceleration,

--- a/src/ui/ProgressWidget.cpp
+++ b/src/ui/ProgressWidget.cpp
@@ -41,8 +41,7 @@ ProgressWidget::ProgressWidget(const QString& headerLabelText, Parameters::Basic
                                        DialogSettings::getStaticParameter("max_threads", std::thread::hardware_concurrency()), this);
         break;
     case Utils::UI::TOOL_ID::PCDS_TO_BAG:
-        m_thread = new PCDsToBagThread(dynamic_cast<Parameters::PCDsToBagParameters&>(parameters),
-                                       DialogSettings::getStaticParameter("max_threads", std::thread::hardware_concurrency()), this);
+        m_thread = new PCDsToBagThread(dynamic_cast<Parameters::PCDsToBagParameters&>(parameters), this);
         break;
     case Utils::UI::TOOL_ID::BAG_TO_IMAGES:
         m_thread = new BagToImagesThread(dynamic_cast<Parameters::BagToImagesParameters&>(parameters),

--- a/test/ros/threads/ThreadsTest.cpp
+++ b/test/ros/threads/ThreadsTest.cpp
@@ -30,10 +30,10 @@
 
 #include <filesystem>
 
-#ifdef ROS_JAZZY
-#include <cv_bridge/cv_bridge.hpp>
-#else
+#ifdef ROS_HUMBLE
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
 #endif
 
 // Because of parallelized bag writing, the topic order in the output bag files might be different with each run

--- a/test/ros/threads/ThreadsTest.cpp
+++ b/test/ros/threads/ThreadsTest.cpp
@@ -608,7 +608,7 @@ TEST_CASE("Threads Testing", "[threads]") {
         parameters.topicName = "/point_clouds_are_awesome";
         parameters.rate = 2;
 
-        auto* const thread = new PCDsToBagThread(parameters, std::thread::hardware_concurrency());
+        auto* const thread = new PCDsToBagThread(parameters);
         QObject::connect(thread, &PCDsToBagThread::finished, thread, &QObject::deleteLater);
 
         thread->start();

--- a/test/utils/UtilsROSTest.cpp
+++ b/test/utils/UtilsROSTest.cpp
@@ -43,10 +43,10 @@ TEST_CASE("Utils ROS Testing", "[utils]") {
     outputStorage.uri = "compressed_bag_file";
 
     rosbag2_transport::RecordOptions outputRecord;
-#ifdef ROS_JAZZY
-    outputRecord.all_topics = true;
-#else
+#ifdef ROS_HUMBLE
     outputRecord.all = true;
+#else
+    outputRecord.all_topics = true;
 #endif
     outputRecord.compression_format = "zstd";
     outputRecord.compression_mode = "file";


### PR DESCRIPTION
- Make ROS dependent code structuring dependent on Humble instead of Jazzy. This might be a cleaner solution for the future, as new ROS versions are going to be released.
- Fix possible wrong ordering in the pcds to bag file tool
  - As of now, this will disable multithreading for this tool, bc there is no clean way to write messages with timestamps in order using multithreading, at least not for Humble (seems to be possible for Jazzy, though). Have to find a better solution in the future for this one.