### PR TITLE
Cherry pick latest fixes from `dev`

### DIFF
--- a/src/ui/InputWidgets/DummyBagWidget.cpp
+++ b/src/ui/InputWidgets/DummyBagWidget.cpp
@@ -97,7 +97,9 @@ DummyBagWidget::createNewDummyTopicWidget(const Parameters::DummyBagParameters::
     });
 
     // Keep it all inside the main form layout
-    m_formLayout->insertRow(m_formLayout->rowCount() - 3, "Topic " + QString::number(m_numberOfTopics + 1) + ":", dummyTopicWidget);
+    // Ensure that the plus and minus button stay below the newly formed widget (row count 4 means no topic widgets yet)
+    m_formLayout->insertRow(m_formLayout->rowCount() == 4 ? m_formLayout->rowCount() - 3 : m_formLayout->rowCount() - 4,
+                            "Topic " + QString::number(m_numberOfTopics + 1) + ":", dummyTopicWidget);
     m_dummyTopicWidgets.push_back(dummyTopicWidget);
 
     m_numberOfTopics++;

--- a/src/ui/ProgressWidget.hpp
+++ b/src/ui/ProgressWidget.hpp
@@ -3,6 +3,7 @@
 #include "Parameters.hpp"
 #include "UtilsUI.hpp"
 
+#include <QMovie>
 #include <QPointer>
 #include <QWidget>
 
@@ -34,5 +35,11 @@ signals:
     finished();
 
 private:
+    bool
+    event(QEvent *event) override;
+
+private:
     QPointer<BasicThread> m_thread;
+
+    QPointer<QMovie> m_movie;
 };


### PR DESCRIPTION
Fixes:
- Gif icons not being updated if system theme changed while thread operation was performed
- Dummy bag topics were sometimes put into the wrong row