### PR TITLE
Fix runtime error when UI was closed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include <signal.h>
-
 #include <QApplication>
 
 int
@@ -16,14 +14,10 @@ main(int argc, char* argv[])
     MainWindow mainWindow;
     mainWindow.show();
 
-    rclcpp::Rate loopRate(60);
     while (rclcpp::ok()) {
         app.processEvents();
-        loopRate.sleep();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
-
-    // Allow keyboard interrupts
-    signal(SIGINT, SIG_DFL);
 
     rclcpp::shutdown();
     return EXIT_SUCCESS;


### PR DESCRIPTION
Apparently, since ROS2 Jazzy, rclcpp::Rate handling got more complex, now it throws runtime errors if used together with POSIX style closing signals. No idea why this happens, but switching to a classic `std::this_thread::sleep_for` resolves the problem.